### PR TITLE
Update pyproject.toml: metadata, classifiers, URLs, format fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,40 @@ description = "Python library for building modular CLI applications"
 authors = [{ name = "kolo", email = "kolo.is.main@gmail.com" }]
 requires-python = ">=3.12,<3.15"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
+keywords = ["cli", "cli-app", "command-line", "terminal", "modular", "framework"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: User Interfaces",
+    "Topic :: Terminals",
+    "Environment :: Console",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3 :: Only",
+    "Typing :: Typed",
+]
 dependencies = [
     "rich (>=14.0.0,<15.0.0)",
     "art (>=6.4,<7.0)",
     "dishka>=1.7.2",
     "prompt-toolkit>=3.0.52",
 ]
+
+[project.urls]
+Homepage = "https://argenta.readthedocs.io"
+Documentation = "https://argenta.readthedocs.io"
+Repository = "https://github.com/koloideal/Argenta"
+Issues = "https://github.com/koloideal/Argenta/issues"
+Changelog = "https://github.com/koloideal/Argenta/blob/master/CHANGELOG.md"
+
+[project.scripts]
+argenta = "argenta._cli.__main__:main"
 
 [project.optional-dependencies]
 cli = [
@@ -57,11 +84,8 @@ metrics = [
     "pygal>=3.1.0",
 ]
 
-[project.scripts]
-argenta = "argenta._cli.__main__:main"
-
 [tool.ruff]
-line-length=100
+line-length = 100
 
 [tool.pyright]
 typeCheckingMode = "strict"
@@ -102,8 +126,8 @@ md_header_level = "2"
 disable_error_code = "import-untyped"
 
 [tool.isort]
-line_length=90
+line_length = 90
 
 [build-system]
-requires = ["uv_build"]
+requires = ["uv_build>=0.4,<0.12"]
 build-backend = "uv_build"


### PR DESCRIPTION
## Changes

- Added project metadata: license (MIT), keywords, classifiers
- Added [project.urls] section (homepage, docs, repo, issues, changelog)
- Moved [project.scripts] to its proper section
- Reformatted line-length and line_length with spaces around =
- Updated build-system requires to uv_build>=0.4,<0.12
- Added license-files field